### PR TITLE
Fix nav-main

### DIFF
--- a/template-parts/nav-main.php
+++ b/template-parts/nav-main.php
@@ -18,8 +18,8 @@
 	<div class="mdlwp-search-box mdl-textfield mdl-js-textfield mdl-textfield--expandable mdl-textfield--floating-label mdl-textfield--align-right mdl-textfield--full-width">   
       <?php get_search_form(); ?>
     </div>
-
-  
+  <!-- Navigation. We hide it in small screens. -->
+  <div class="mdlwp-navigation-container">
     <?php
 		$args = array(
 	        'theme_location' => 'primary',
@@ -33,5 +33,6 @@
 		       wp_nav_menu($args);
 		    }
 	?>
+	</div>
     
 </div>


### PR DESCRIPTION
fix nav-main transition
## suggest

style.css

.mdlwp-navigation-container {
  direction: rtl;
  -webkit-box-ordinal-group: 2;
  -webkit-order: 1;
      -ms-flex-order: 1;
          order: 1;
  ~~width: 500px;~~
  -webkit-transition: opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1), width 0.2s cubic-bezier(0.4, 0, 0.2, 1);
          transition: opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1), width 0.2s cubic-bezier(0.4, 0, 0.2, 1); }

remove  width: 500px; // mobile nav-main width err
