### PR TITLE
Bugfix for 404 Not found errors in theme customizer

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -36,6 +36,7 @@ function mdlwp_customize_register( $wp_customize ) {
 		// $args
 		array(
 			'indigo'			=> '#3F51B5',
+			'default'			=> 'indigo',
 		)
 	);
 
@@ -56,6 +57,7 @@ function mdlwp_customize_register( $wp_customize ) {
 		// $args
 		array(
 			'pink'			=> '#E91E63',
+			'default'		=> 'pink',
 		)
 	);
 


### PR DESCRIPTION
If `default` argument is not set for `$wp_customize->add_setting`, then the theme will render stylesheets like so: `http://storage.googleapis.com/code.getmdl.io/1.1.3/material.-.min.css?ver=4.5.2`
Setting `default` is required, even though the same value is set `inc/scripts.php` in `get_theme_mod()`
